### PR TITLE
Attempt to add swagger-ui to project

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "dependencies": {
     "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react-dom": "^15.5.4",
+    "swagger-ui": "^3.0.11"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -1,18 +1,13 @@
 import React, { Component } from 'react';
 import logo from './logo.svg';
 import './App.css';
+import SwaggerUI from './components/swagger'
 
 class App extends Component {
   render() {
     return (
       <div className="App">
-        <div className="App-header">
-          <img src={logo} className="App-logo" alt="logo" />
-          <h2>Welcome to React</h2>
-        </div>
-        <p className="App-intro">
-          To get started, edit <code>src/App.js</code> and save to reload.
-        </p>
+        <SwaggerUI />
       </div>
     );
   }

--- a/src/components/swagger.js
+++ b/src/components/swagger.js
@@ -1,0 +1,34 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+
+import SwaggerUi, {presets} from 'swagger-ui';
+import 'swagger-ui/dist/swagger-ui.css';
+
+class SwaggerUI extends Component {
+
+    componentDidMount() {
+        SwaggerUi({
+            dom_id: '#swaggerContainer',
+            url: this.props.url,
+            spec: this.props.spec,
+            presets: [presets.apis]
+        });
+    }
+
+    render() {
+        return (
+            <div id="swaggerContainer" />
+        );
+    }
+}
+
+SwaggerUI.propTypes = {
+    url: PropTypes.string,
+    spec: PropTypes.object
+};
+
+SwaggerUI.defaultProps = {
+    url: `http://petstore.swagger.io/v2/swagger.json`
+};
+
+export default SwaggerUI;


### PR DESCRIPTION
Adopting the example from this
[comment](https://github.com/swagger-api/swagger-ui/issues/3000#issuecomment-298679801)
to fit into the create-react-app boiler plate.

Unfortunately this is not working right now :(

If you start the dev-server (`npm start`) and visit localhost, you'll see the following error:

![image](https://cloud.githubusercontent.com/assets/5312329/26455213/d9f47d8e-4169-11e7-86a9-93b5317718ff.png)
